### PR TITLE
Update README-zh.md本地sse启动命令错误

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -273,10 +273,10 @@ mcp json 如下
 uv sync
 
 # 启动
-uv run -m mysql_mcp_server_pro.server --mode sse
+uv run -m core.server --mode sse
 
 # 自定义env文件位置
-uv run -m mysql_mcp_server_pro.server --mode sse --envfile /path/to/.env
+uv run -m core.server --mode sse --envfile /path/to/.env
 ```
 
 ### 本地开发 STDIO 方式 


### PR DESCRIPTION
本地sse启动命令启动的 mysql_mcp_server_pro.server 是不是应该改为 core.server ？我在本地启动报找不到 mysql_mcp_server_pro.server